### PR TITLE
Award no points if the password contains "password"

### DIFF
--- a/javascripts/naked_password.js
+++ b/javascripts/naked_password.js
@@ -38,7 +38,11 @@ function toggleImg(field, level){
 
 function getPasswordStrength(password){
 var score = 0;
- 
+
+// Worst password ever.  No points!
+if (password.match(/password/) )
+{ return 0; }
+
 //if password bigger than 4 give 1 point
 if (password.length > 4) { score++; }
  


### PR DESCRIPTION
Right now the girl takes off her shirt if the password is "password".  That doesn't seem right.

Great plugin!
